### PR TITLE
Add siem-agent-test-vm on proxmox3 to Terraform configuration

### DIFF
--- a/docs/diagrams/config.py
+++ b/docs/diagrams/config.py
@@ -55,6 +55,7 @@ VMS = {
     "proxmox3": [
         {"name": "security-tooling-01", "cores": 4, "mem_gb": 16, "disk_gb": 300, "template": 9005, "tags": ["security"]},
         {"name": "k3s-01", "cores": 4, "mem_gb": 16, "disk_gb": 300, "template": 9005, "tags": ["k3s"]},
+        {"name": "siem-agent-test-vm", "cores": 8, "mem_gb": 24, "disk_gb": 250, "template": 9005, "tags": ["siem"]},
     ],
 }
 

--- a/infrastructure_tooling/proxmox/terraform/main.tf
+++ b/infrastructure_tooling/proxmox/terraform/main.tf
@@ -189,6 +189,28 @@ module "k3s_01" {
   vm_password    = var.vm_password
 }
 
+# SIEM Agent Test VM on proxmox3
+module "siem_agent_test_vm" {
+  source = "./modules/proxmox-vm"
+
+  vm_name        = "siem-agent-test-vm"
+  description    = "Terraform-managed Ubuntu 24.04 VM for SIEM agent testing on proxmox3"
+  tags           = ["terraform", "ubuntu", "siem"]
+  target_node    = "proxmox3"
+  template_vm_id = 9005
+  cores          = 8
+  memory         = 24576
+  disk_size      = "250"
+
+  # Shared configuration
+  disk_storage   = var.disk_storage
+  network_bridge = var.network_bridge
+  dns_servers    = var.dns_servers
+  dns_domain     = var.dns_domain
+  vm_username    = "ubuntu"
+  vm_password    = var.vm_password
+}
+
 # output "vm_ip_addresses" {
 #   description = "IP addresses of the created VMs"
 #   value = {


### PR DESCRIPTION
## Summary

Adds a new Terraform-managed VM, `siem-agent-test-vm`, on the `proxmox3` node for SIEM agent testing. Spec: 8 vCPU, 24 GB RAM, 250 GB disk.

## Changes

- `infrastructure_tooling/proxmox/terraform/main.tf` — new `module "siem_agent_test_vm"` block using the shared `./modules/proxmox-vm` module. Follows the existing proxmox3 pattern (`security-tooling-01`, `k3s-01`): `target_node = "proxmox3"` hardcoded, `template_vm_id = 9005` (the Ubuntu Server template built by Packer on proxmox3), tags `["terraform", "ubuntu", "siem"]`.
  - `cores = 8` (8 vCPU on 1 socket — the module sets no `sockets`)
  - `memory = 24576` (MB → 24 GB)
  - `disk_size = "250"` (GB, string, per module convention)
- `docs/diagrams/config.py` — matching entry in the `VMS["proxmox3"]` inventory so generated diagrams stay in sync.

## Impact

- **No existing infrastructure is modified.** The plan should show exactly one resource to add: `module.siem_agent_test_vm.proxmox_virtual_environment_vm.vm`.
- **The VM is not created by merging this PR.** Creation requires manually dispatching the `Terraform Apply` workflow (`workflow_dispatch`, `prod` environment) after merge.
- No new variables, tfvars, or GitHub secrets required — proxmox3 VMs hardcode `target_node` rather than using the `coalesce(var.target_node_<vm>, var.target_node)` override pattern.
- Networking is DHCP on `vmbr0` (the shared module hardcodes `ipv4.address = "dhcp"`); Proxmox auto-assigns the VMID and MAC.
- Diagram PNGs were intentionally not regenerated in this PR, matching the precedent set when `k3s-01` was added.