### PR TITLE
Fix ARC runners: restore arc-github-token via ExternalSecret

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ The ARC runner uses Kubernetes container mode. Workflows must specify a containe
 ```yaml
 jobs:
   build:
-    runs-on: arc-k3s-runner
+    runs-on: arc-k3s-homelab
     container:
       image: ubuntu:24.04
     steps:
@@ -520,7 +520,7 @@ jobs:
 | Runner | Label | Type |
 |--------|-------|------|
 | VM Runner | `[self-hosted, Linux, X64]` | Persistent VM |
-| ARC Runner | `arc-k3s-runner` | Ephemeral K8s pods |
+| ARC Runner | `arc-k3s-homelab` | Ephemeral K8s pods |
 
 ## Applications
 ### Alex Printer tracker
@@ -722,7 +722,7 @@ The `infrastructure_tooling/proxmox/` directory contains comprehensive automatio
 
 | Workflow | Trigger | Runner | Description |
 |----------|---------|--------|-------------|
-| `proxmox-packer-builder.yml` | Manual, Schedule, Push | `arc-k3s-runner` | Builds templates on both nodes in parallel |
+| `proxmox-packer-builder.yml` | Manual, Schedule, Push | `arc-k3s-homelab` | Builds templates on both nodes in parallel |
 | `terraform-validate-and-plan.yml` | Manual, Push/PR | `self-hosted` | Validates and plans Terraform changes |
 | `terraform-apply.yml` | Manual | `self-hosted` | Applies Terraform configuration |
 

--- a/infrastructure_tooling/arc_runner_scaleset/.helmignore
+++ b/infrastructure_tooling/arc_runner_scaleset/.helmignore
@@ -1,0 +1,7 @@
+# claude-mem writes CLAUDE.md context stubs into chart dirs (including templates/).
+# They are gitignored so ArgoCD never sees them, but Helm tries to render any file
+# under templates/ and fails with:
+#   Error: YAML parse error on arc-runner-scaleset/templates/CLAUDE.md
+# Excluding them keeps `helm template` / `helm lint` usable locally.
+CLAUDE.md
+.claude/

--- a/infrastructure_tooling/arc_runner_scaleset/values.yaml
+++ b/infrastructure_tooling/arc_runner_scaleset/values.yaml
@@ -23,7 +23,13 @@ gha-runner-scale-set:
           storage: 10Gi
 
 externalSecret:
-  enabled: false  # Secret already created manually
+  # Owns the shared arc-github-token secret for BOTH scale sets in arc-runners.
+  # Deliberately enabled here only -- arc_runner_scaleset_daily_news renders a
+  # secret of the same name in the same namespace, so enabling both would make
+  # two ArgoCD apps claim one resource.
+  # Was previously created by hand; that manual step was lost in the bmo-nuc ->
+  # k3s-01 migration and left every ARC runner dead from 2026-04-20.
+  enabled: true
   refreshInterval: "1h"
   secretStoreName: vault-backend
   vaultPath: kv/github-arc

--- a/infrastructure_tooling/arc_runner_scaleset_daily_news/.helmignore
+++ b/infrastructure_tooling/arc_runner_scaleset_daily_news/.helmignore
@@ -1,0 +1,7 @@
+# claude-mem writes CLAUDE.md context stubs into chart dirs (including templates/).
+# They are gitignored so ArgoCD never sees them, but Helm tries to render any file
+# under templates/ and fails with:
+#   Error: YAML parse error on arc-runner-scaleset-daily-news/templates/CLAUDE.md
+# Excluding them keeps `helm template` / `helm lint` usable locally.
+CLAUDE.md
+.claude/

--- a/infrastructure_tooling/arc_runner_scaleset_daily_news/values.yaml
+++ b/infrastructure_tooling/arc_runner_scaleset_daily_news/values.yaml
@@ -23,7 +23,13 @@ gha-runner-scale-set:
           storage: 10Gi
 
 externalSecret:
-  enabled: false  # Secret already created manually
+  # Intentionally disabled -- do not flip this to true.
+  # The arc_runner_scaleset chart creates the shared arc-github-token secret in
+  # this same namespace (arc-runners). Enabling it here too would make the
+  # arc-runner-scaleset-k3s and arc-runner-daily-news-k3s ArgoCD apps both own
+  # the same resource. This scale set consumes the secret that chart creates,
+  # so the PAT/App in Vault kv/github-arc must cover daily_news_app as well.
+  enabled: false
   refreshInterval: "1h"
   secretStoreName: vault-backend
   vaultPath: kv/github-arc


### PR DESCRIPTION
## Problem

Every `Build Proxmox Packer Template` run since **2026-04-20** (17 consecutive) was cancelled at exactly `24h0m2s`:

> The job has exceeded the maximum execution time while awaiting a runner for 24h0m0s

The jobs never started — nothing ever registered for the `arc-k3s-homelab` label. Last green build was 2026-04-13, which matches the `ubuntu-2404-20260413` templates still sitting on the Proxmox nodes.

## Root cause

The secret `arc-runners/arc-github-token` did not exist. `kubectl -n arc-runners get secrets` returned nothing, and the ARC controller had been erroring on every reconcile:

```
ERROR AutoscalingRunnerSet  Failed to initialize Actions service client for creating a new runner scale set
  error: "failed to resolve app config: failed to get kubernetes secret: \"arc-runners/arc-github-token\""
```

So both `AutoscalingRunnerSet` CRs sat with blank status — no `AutoscalingListener`, no `EphemeralRunnerSet`, no runner pods.

The secret had been created by hand on bmo-nuc (`values.yaml` even said so: `enabled: false  # Secret already created manually`) and was never recreated during the 2026-05-10 migration to k3s-01. Helm owned the ServiceAccounts/Roles/RoleBindings so those carried over; the hand-made secret did not, because nothing in Git described it.

ArgoCD reported both ARC apps `Synced`/`Healthy` the whole time — the CRs apply cleanly, and ArgoCD has no visibility into the controller failing to act on them. That is why a hard outage stayed invisible for ~4 months.

## Changes

- **`arc_runner_scaleset/values.yaml`** — `externalSecret.enabled: false` to `true`. The token now comes from Vault `kv/github-arc` through the existing `vault-backend` ClusterSecretStore, so it survives the next cluster rebuild. No template changes needed; `templates/externalsecret.yaml` was already gated on exactly this flag.
- **`arc_runner_scaleset_daily_news/values.yaml`** — left disabled, with a comment explaining why. Both charts render a secret named `arc-github-token` in the same namespace, so enabling both would make two ArgoCD apps own one resource.
- **`README.md`** — runner label `arc-k3s-runner` to `arc-k3s-homelab` in 3 places. The documented label never existed; copying the README example produced a job that queues until GitHub cancels it.
- **`.helmignore`** (new, both charts) — claude-mem drops `CLAUDE.md` stubs into `templates/`, which made `helm template` fail with `YAML parse error on .../templates/CLAUDE.md`. Gitignored so ArgoCD was unaffected, but it blocked local rendering.

## Verification done before merge

- Vault `kv/github-arc` confirmed to hold exactly the key `github_token` (verified against the deployed chart's appconfig resolution — any other key name reproduces the same error).
- PAT validated: `HTTP 200` against the Actions runners API for **both** `bmorri13/homelab` and `bmorri13/daily_news_app`, scope `repo`. Both scale sets share this one secret.
- `helm template` renders exactly one ExternalSecret from the homelab chart with the correct `key: kv/github-arc` / `property: github_token`; zero from daily-news; neither chart creates its own Secret (`githubConfigSecret` is a string reference).
- Rendered chart is `gha-rs-0.13.1`, matching the deployed `gha-runner-scale-set-controller:0.13.1` — see the version note below.

## Post-merge verification

```bash
kubectl -n arc-runners get externalsecret,secret          # SecretSynced / True
kubectl get autoscalingrunnerset -A                       # columns populated, not blank
kubectl -n arc-systems get pods | grep listener           # listener pod Running
gh workflow run proxmox-packer-builder.yml                # runner picks up in ~seconds
```

## Ruled out — not problems

All three Proxmox nodes are online and quorate and hold the referenced ISOs; templates 9000/9005/9006 exist. The `iso_checksum` default (24.04.2 hash) vs the forced 24.04.3 ISO is harmless — the proxmox-iso builder does not checksum pre-uploaded `iso_file` volumes, and the last green build ran this exact combination.

## Follow-ups deliberately not in this PR

- **Do not resolve the `gha-runner-scale-set` version drift by moving to 0.14.2.** `Chart.yaml`/`Chart.lock` say 0.14.2 but the vendored tarball is 0.13.1, and 0.13.1 is what renders and runs — matching the 0.13.1 controller. ARC deletes any `AutoscalingRunnerSet` whose chart version mismatches on major/minor, so re-vendoring 0.14.2 against the 0.13.1 controller would cause a delete/recreate loop against ArgoCD `selfHeal`. Pin *down* to 0.13.1, and treat 0.14.x as a coordinated upgrade.
- **`minRunners: 1`** would make the next occurrence visible immediately. With `minRunners: 0`, a dead listener is indistinguishable from an idle one. Note that `timeout-minutes` would *not* have helped: GitHub's 24h ceiling is queue time and isn't configurable.
