### PR TITLE
Stop ArgoCD pruning ARC's controller-managed runtime objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.pas
 
 - You are now ready to install your first apps!
 
+#### ArgoCD server configuration (`argocd-cm`)
+
+ArgoCD's own settings live in [`infrastructure_tooling/argocd_config`](infrastructure_tooling/argocd_config), deployed as the `argocd-config` app. Unlike every other app here, its Application manifest **is** committed — losing it would silently reintroduce the problems it prevents. Bootstrap it once:
+
+```bash
+kubectl apply -f infrastructure_tooling/argocd_config/application.yaml
+```
+
+That chart is the source of truth for `argocd-cm`. Settings added through the ArgoCD UI that are not in the chart get reverted on the next sync — put them in the chart instead. It currently configures two things:
+
+| Setting | Why |
+|---------|-----|
+| `resource.exclusions` for `AutoscalingListener`, `EphemeralRunner`, `EphemeralRunnerSet` | The ARC controller stamps `app.kubernetes.io/instance` onto the runtime objects it creates. ArgoCD reads that as its own tracking label, sees resources absent from Git, and prunes them; the controller recreates them, looping every reconcile. `AutoscalingRunnerSet` is deliberately **not** excluded — that one does come from Git. |
+| Ingress health override | Traefik runs hostNetwork with its Service disabled and there is no MetalLB, so `status.loadBalancer` never populates and ArgoCD's built-in check would leave every Ingress-owning app stuck at `Progressing`. |
+
 ### Vault 
 - In order to manage kubernetes secrets, we will deploy [Vault](https://developer.hashicorp.com/vault/docs/platform/k8s/helm)
 >NOTE: This is just one example of a password manager, you can use local secrets, or other soultions such as AWS Secrets manager, GCP Secrets Manager, etc.

--- a/infrastructure_tooling/argocd_config/.helmignore
+++ b/infrastructure_tooling/argocd_config/.helmignore
@@ -1,0 +1,7 @@
+# claude-mem writes CLAUDE.md context stubs into chart dirs (including templates/).
+# They are gitignored so ArgoCD never sees them, but Helm tries to render any file
+# under templates/ and fails with:
+#   Error: YAML parse error on argocd-config/templates/CLAUDE.md
+# Excluding them keeps `helm template` / `helm lint` usable locally.
+CLAUDE.md
+.claude/

--- a/infrastructure_tooling/argocd_config/Chart.yaml
+++ b/infrastructure_tooling/argocd_config/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: argocd-config
+description: ArgoCD server configuration (argocd-cm) for the k3s-01 cluster
+type: application
+version: 0.1.0
+appVersion: "1"

--- a/infrastructure_tooling/argocd_config/application.yaml
+++ b/infrastructure_tooling/argocd_config/application.yaml
@@ -1,0 +1,31 @@
+---
+# Bootstrap manifest for the argocd-config app.
+#
+# There is no app-of-apps in this repo, so ArgoCD Applications are normally
+# created through the UI and exist nowhere in Git. This one is committed because
+# it configures ArgoCD itself -- losing it would silently reintroduce the ARC
+# prune loop it exists to prevent.
+#
+# Apply once:
+#   kubectl apply -f infrastructure_tooling/argocd_config/application.yaml
+#
+# prune is deliberately false: this app manages ArgoCD's own ConfigMap, and a
+# mis-render that pruned argocd-cm would take ArgoCD's configuration with it.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/bmorri13/homelab
+    targetRevision: HEAD
+    path: infrastructure_tooling/argocd_config
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true

--- a/infrastructure_tooling/argocd_config/templates/argocd-cm.yaml
+++ b/infrastructure_tooling/argocd_config/templates/argocd-cm.yaml
@@ -1,0 +1,57 @@
+---
+# ArgoCD server configuration.
+#
+# IMPORTANT: this ConfigMap is the source of truth for ArgoCD's own settings on
+# k3s-01. ArgoCD adopts the existing (empty) argocd-cm on first sync. Any setting
+# added through the ArgoCD UI that is not represented here will be reverted on the
+# next sync -- add it to this file instead.
+#
+# The app.kubernetes.io/part-of: argocd label is REQUIRED; ArgoCD locates its own
+# config by that label and ignores a ConfigMap without it.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+data:
+{{- if .Values.resourceExclusions.arc.enabled }}
+  # The ARC controller copies the AutoscalingRunnerSet's Helm labels -- including
+  # app.kubernetes.io/instance -- onto the AutoscalingListener, EphemeralRunnerSet
+  # and EphemeralRunner objects it creates at runtime. ArgoCD reads that label as
+  # its own tracking label, concludes it owns resources that do not exist in Git,
+  # and with prune enabled deletes them. The controller immediately recreates them,
+  # producing a delete/recreate loop every reconcile (~3 min) that churns the
+  # listener pods and intermittently delays job pickup.
+  #
+  # Excluding these three controller-managed kinds stops ArgoCD from tracking them
+  # at all. They will not appear in the ArgoCD UI -- that is intended; their
+  # lifecycle belongs to the ARC controller, not to Git.
+  #
+  # Do NOT exclude AutoscalingRunnerSet: that one IS rendered from Git by the
+  # arc_runner_scaleset charts and must stay under ArgoCD's control.
+  resource.exclusions: |
+    - apiGroups:
+        - actions.github.com
+      kinds:
+        - AutoscalingListener
+        - EphemeralRunner
+        - EphemeralRunnerSet
+      clusters:
+        - "*"
+{{- end }}
+{{- if .Values.resourceCustomizations.ingressHealth.enabled }}
+  # Traefik on this cluster runs hostNetwork with its Service disabled
+  # (service.enabled: false in the traefik HelmChartConfig) and there is no
+  # MetalLB, so Ingress objects never get status.loadBalancer.ingress populated.
+  # ArgoCD's built-in Ingress health check waits for exactly that field, so every
+  # app owning an Ingress would sit at "Progressing" forever. Treat a synced
+  # Ingress as Healthy instead.
+  resource.customizations.health.networking.k8s.io_Ingress: |
+    hs = {}
+    hs.status = "Healthy"
+    hs.message = "Ingress is served by hostNetwork Traefik; no loadBalancer status expected on this cluster"
+    return hs
+{{- end }}

--- a/infrastructure_tooling/argocd_config/values.yaml
+++ b/infrastructure_tooling/argocd_config/values.yaml
@@ -1,0 +1,15 @@
+---
+# values.yaml
+## Configuration for ArgoCD's own argocd-cm ConfigMap on k3s-01.
+
+resourceExclusions:
+  arc:
+    # Stop ArgoCD tracking (and pruning) the runtime objects the ARC controller
+    # creates. See templates/argocd-cm.yaml for the full explanation.
+    enabled: true
+
+resourceCustomizations:
+  ingressHealth:
+    # Report Ingress resources as Healthy despite an empty status.loadBalancer,
+    # which never populates on this cluster's hostNetwork Traefik setup.
+    enabled: true


### PR DESCRIPTION
## Problem

Once the ARC runners came back up in #127, both ARC apps flipped to `OutOfSync` and ArgoCD started deleting the listeners on every reconcile. From ArgoCD's own controller log:

```
Adding resource result, status: 'Pruned', phase: 'Succeeded', message: 'pruned'
  kind=AutoscalingListener name=arc-k3s-homelab-6d6c78bf-listener namespace=arc-systems
  SelfHealAttemptsCount:20
```

Observed directly — listener pods destroyed and recreated on a ~3 minute cycle:

```
t+60s   daily-news=2m47s  homelab=96s
t+90s   daily-news=3m17s  homelab=2m6s
t+150s  daily-news=88s    homelab=17s     <- both recreated
```

## Root cause

The ARC controller copies the `AutoscalingRunnerSet`'s Helm labels — including **`app.kubernetes.io/instance: arc-runner-scaleset-k3s`** — onto the `AutoscalingListener`, `EphemeralRunnerSet` and `EphemeralRunner` objects it creates at runtime:

```
kubectl -n arc-systems get autoscalinglistener arc-k3s-homelab-6d6c78bf-listener -o jsonpath='{.metadata.labels}'
{"actions.github.com/scale-set-name":"arc-k3s-homelab", ...,
 "app.kubernetes.io/instance":"arc-runner-scaleset-k3s", ...}
```

That is ArgoCD's tracking label. ArgoCD concludes it owns a resource that does not exist in Git and, with `prune: true`, deletes it along with its Role and RoleBinding. The controller recreates them seconds later. Loop.

**This was latent before #127.** With no GitHub token there were no listeners for ArgoCD to prune, so the loop had nothing to act on. Restoring the runners is what surfaced it.

Impact was degradation, not breakage — the controller rebuilds within seconds, which is why the Packer run still went 7/7 green. The cost was listener churn and intermittently delayed job pickup.

## Changes

New `infrastructure_tooling/argocd_config` chart owning `argocd-cm`, configuring two things:

**1. `resource.exclusions` for the ARC runtime kinds** — `AutoscalingListener`, `EphemeralRunner`, `EphemeralRunnerSet`. ArgoCD stops tracking them entirely; their lifecycle belongs to the ARC controller, not to Git. They will no longer appear in the ArgoCD UI, which is intended.

> `AutoscalingRunnerSet` is deliberately **not** excluded — that one *is* rendered from Git by the `arc_runner_scaleset` charts and must stay under ArgoCD's control.

**2. Ingress health customization** — Traefik on this cluster runs hostNetwork with `service.enabled: false` and there is no MetalLB, so `status.loadBalancer.ingress[]` never populates. ArgoCD's built-in Ingress health check waits for exactly that field, so any app owning an Ingress sits at `Progressing` forever. `stirling-pdf` has been in that state since #128. This reports a synced Ingress as Healthy instead.

The **Application manifest is committed** (`application.yaml`) rather than left as UI-only state. No other Application in this repo is in Git, but losing this one would silently reintroduce the loop it prevents — the same failure pattern as #127 and #128.

## Safety

- `argocd-cm` currently has **no `data` keys at all** (verified), so adopting it is purely additive.
- The required `app.kubernetes.io/part-of: argocd` label is preserved — ArgoCD locates its own config by it.
- The app is set `prune: false`, so a mis-render cannot take `argocd-cm` with it.
- `application.yaml` sits at the chart root, not under `templates/`, so Helm does not render it — verified, no recursion.

## Interim mitigation already applied

To stop the churn immediately, `prune: false` was set live on both ARC apps. Verified stable — both listeners aged monotonically over 3.5 minutes with zero restarts:

```
t+30s   daily-news=2m17s  homelab=66s
t+210s  daily-news=5m17s  homelab=4m6s
```

Note this was applied directly to the cluster and those Applications are not in Git. Once this PR is merged and synced, the exclusions make prune safe again and `prune: true` can be restored on both ARC apps — worth doing so genuinely-removed resources resume being cleaned up.

## Deploy

```bash
kubectl apply -f infrastructure_tooling/argocd_config/application.yaml
kubectl -n argocd get cm argocd-cm -o jsonpath='{.data}'      # exclusions present
kubectl -n arc-systems get pods                                # listener ages climb, no restarts
kubectl -n argocd get app stirling-pdf                         # Synced / Healthy, not Progressing
```
