### PR TITLE
Correct guidance: ARC apps must keep prune disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ That chart is the source of truth for `argocd-cm`. Settings added through the Ar
 | `resource.exclusions` for `AutoscalingListener`, `EphemeralRunner`, `EphemeralRunnerSet` | The ARC controller stamps `app.kubernetes.io/instance` onto the runtime objects it creates. ArgoCD reads that as its own tracking label, sees resources absent from Git, and prunes them; the controller recreates them, looping every reconcile. `AutoscalingRunnerSet` is deliberately **not** excluded — that one does come from Git. |
 | Ingress health override | Traefik runs hostNetwork with its Service disabled and there is no MetalLB, so `status.loadBalancer` never populates and ArgoCD's built-in check would leave every Ingress-owning app stuck at `Progressing`. |
 
+> **The two ARC apps must keep `prune: false`.** The exclusions above stop ArgoCD tracking the `actions.github.com` kinds, but the ARC controller also creates a **Role and RoleBinding** per listener — core RBAC kinds, so no `apiGroups`-based exclusion can cover them without excluding all RBAC cluster-wide. Those still carry the `app.kubernetes.io/instance` label, so re-enabling prune would resume deleting them and restart the loop. Expect `arc-runner-scaleset-k3s` and `arc-runner-daily-news-k3s` to sit permanently `OutOfSync / Healthy` — that is the intended steady state, not drift to fix.
+
 ### Vault 
 - In order to manage kubernetes secrets, we will deploy [Vault](https://developer.hashicorp.com/vault/docs/platform/k8s/helm)
 >NOTE: This is just one example of a password manager, you can use local secrets, or other soultions such as AWS Secrets manager, GCP Secrets Manager, etc.


### PR DESCRIPTION
Correction to #129, confirmed on-cluster after deploying `argocd-config`.

#129 stated that `prune: true` could be restored on the two ARC apps once the resource exclusions were live. **That is wrong.**

The exclusions do cover the `actions.github.com` kinds — `AutoscalingListener` is no longer tracked, verified. But the ARC controller also creates a **Role and RoleBinding per listener**, and those remain tracked:

```
Role/arc-k3s-homelab-6d6c78bf-listener         sync=OutOfSync
RoleBinding/arc-k3s-homelab-6d6c78bf-listener  sync=OutOfSync
Role/arc-k3s-daily-news-7cd46959-listener      sync=OutOfSync
RoleBinding/arc-k3s-daily-news-7cd46959-listener sync=OutOfSync
```

They carry `app.kubernetes.io/instance` like everything else the controller stamps, but they are **core RBAC kinds**. `resource.exclusions` matches only on `apiGroups`/`kinds`/`clusters` — there is no name or label selector — so excluding them would mean excluding all Roles and RoleBindings cluster-wide. Far too broad.

Re-enabling prune would therefore resume deleting them and restart the churn #129 set out to stop.

This documents that `prune: false` is the intended permanent state for both ARC apps, and that `OutOfSync / Healthy` is their expected steady state rather than drift someone should 'fix'.

## Current verified state

| App | State | Note |
|---|---|---|
| `arc-runner-scaleset-k3s` | OutOfSync / Healthy | expected — controller-created RBAC |
| `arc-runner-daily-news-k3s` | OutOfSync / Healthy | expected — same |
| `stirling-pdf` | Synced / **Healthy** | was Progressing; Ingress health override working |
| `argocd-config` | Synced / Healthy | |

Listener pods stable at 16–17 min uptime, zero restarts (previously destroyed every ~3 min).