### PR TITLE
Keep one ARC runner warm so outages are visible

### DIFF
--- a/infrastructure_tooling/arc_runner_scaleset/values.yaml
+++ b/infrastructure_tooling/arc_runner_scaleset/values.yaml
@@ -12,6 +12,20 @@ gha-runner-scale-set:
   # Runner configuration - use this as runs-on value
   runnerScaleSetName: "arc-k3s-homelab"
 
+  # Keep one runner registered at all times so an ARC outage is visible from
+  # `kubectl -n arc-runners get pods` instead of only surfacing 24h later as a
+  # queue-timeout cancellation. With minRunners at the default 0, a dead listener
+  # is indistinguishable from an idle one -- that is how the missing
+  # arc-github-token secret went unnoticed from 2026-04-20 to 2026-08-08.
+  #
+  # Note this does NOT bound the 24h queue ceiling, which is a GitHub-side limit
+  # on self-hosted jobs and is not configurable; timeout-minutes only starts
+  # counting once a runner picks the job up.
+  #
+  # maxRunners is deliberately left unset (unbounded). The packer workflow fans
+  # out to 5 concurrent build jobs and the node has ample headroom.
+  minRunners: 1
+
   # Container mode (recommended for K8s)
   containerMode:
     type: "kubernetes"


### PR DESCRIPTION
Closes the detection gap behind #127.

## Why

The missing `arc-github-token` secret went unnoticed from **2026-04-20 to 2026-08-08** — 17 consecutive cancelled runs over roughly four months. Nothing surfaced it, because with `minRunners` at the default `0` there is no steady-state signal: a dead listener and an idle scale set look identical from `kubectl -n arc-runners get pods`, and neither shows up in the GitHub runners view.

Setting `minRunners: 1` means a runner is always registered. An outage becomes a missing pod you can see immediately, rather than a queue-timeout cancellation 24 hours after the fact.

## What this does not do

**It has no effect on the 24h queue ceiling.** That is a GitHub-side limit on self-hosted jobs and is not configurable. `timeout-minutes` does not help either — it only starts counting once a runner picks the job up, which never happened during the outage. This buys *detection*, not a shorter failure window.

## Capacity

Checked before making the change — k3s-01 has ample headroom:

| Metric | Value |
|---|---|
| CPU | 91m used, 2% |
| Memory | 5097Mi, 31% |
| Disk (local-path) | 259G free of 296G, 9% used |

`local-path` PVCs are thin-provisioned, so the idle runner's 10Gi claim costs almost nothing at rest.

## Scope

- `maxRunners` deliberately left **unset** (unbounded). The packer workflow fans out to 5 concurrent build jobs and there is headroom for it.
- Applied to the **homelab** scale set only. `arc-k3s-daily-news` stays at the default `0` — say the word if you want it warm too.

## Verified before pushing

`helm template` renders `minRunners: 1` on the `AutoscalingRunnerSet`, no `maxRunners` key, chart still `gha-rs-0.13.1` (matching the deployed controller — see #129/#130 on why that must not move), and the ExternalSecret still renders.

## After merge

`arc-runner-scaleset-k3s` has `selfHeal: true`, so it picks this up automatically. Expect a persistent `arc-k3s-homelab-*-runner-*` pod in `arc-runners` within a few minutes:

```bash
kubectl -n arc-runners get pods
kubectl get autoscalingrunnerset -A   # MINIMUM RUNNERS column shows 1
```