### PR TITLE
Stop publishing the SSH password hash to public run logs

### DIFF
--- a/.github/workflows/proxmox-packer-builder.yml
+++ b/.github/workflows/proxmox-packer-builder.yml
@@ -58,6 +58,9 @@ jobs:
         run: |
           PASSWORD="${{ secrets.SSH_PASSWORD }}"
           HASH=$(openssl passwd -6 "$PASSWORD")
+          # GitHub masks registered secrets, but NOT values derived from them.
+          # Without this, the crypt hash appears verbatim in the (public) run log.
+          echo "::add-mask::$HASH"
           echo "password_hash=$HASH" >> $GITHUB_OUTPUT
 
       - name: Create Dynamic User-Data
@@ -68,8 +71,15 @@ jobs:
           # Escape special characters for sed
           ESCAPED_HASH=$(printf '%s\n' "$HASH" | sed 's/[[\.*^$/]/\\&/g')
           sed -i "s|password: \".*\"|password: \"$ESCAPED_HASH\"|" user-data
-          echo "Updated user-data password hash"
-          grep "password:" user-data
+          # Assert the substitution worked WITHOUT printing the matched line. The
+          # hash is derived from secrets.SSH_PASSWORD, and this repo is public, so
+          # echoing it would publish a crackable credential to the run log.
+          if grep -q 'password: "[$]6[$]' user-data; then
+            echo "user-data password hash substituted OK"
+          else
+            echo "::error::password hash substitution failed in user-data"
+            exit 1
+          fi
 
       - name: Create Variables File
         working-directory: ${{ env.WORKING_DIR }}
@@ -225,6 +235,9 @@ jobs:
         run: |
           PASSWORD="${{ secrets.SSH_PASSWORD }}"
           HASH=$(openssl passwd -6 "$PASSWORD")
+          # GitHub masks registered secrets, but NOT values derived from them.
+          # Without this, the crypt hash appears verbatim in the (public) run log.
+          echo "::add-mask::$HASH"
           echo "password_hash=$HASH" >> $GITHUB_OUTPUT
 
       - name: Create Dynamic User-Data
@@ -235,8 +248,15 @@ jobs:
           # Escape special characters for sed
           ESCAPED_HASH=$(printf '%s\n' "$HASH" | sed 's/[[\.*^$/]/\\&/g')
           sed -i "s|password: \".*\"|password: \"$ESCAPED_HASH\"|" user-data
-          echo "Updated user-data password hash"
-          grep "password:" user-data
+          # Assert the substitution worked WITHOUT printing the matched line. The
+          # hash is derived from secrets.SSH_PASSWORD, and this repo is public, so
+          # echoing it would publish a crackable credential to the run log.
+          if grep -q 'password: "[$]6[$]' user-data; then
+            echo "user-data password hash substituted OK"
+          else
+            echo "::error::password hash substitution failed in user-data"
+            exit 1
+          fi
 
       - name: Create Variables File
         working-directory: ${{ env.WORKING_DIR }}
@@ -329,6 +349,9 @@ jobs:
         run: |
           PASSWORD="${{ secrets.SSH_PASSWORD }}"
           HASH=$(openssl passwd -6 "$PASSWORD")
+          # GitHub masks registered secrets, but NOT values derived from them.
+          # Without this, the crypt hash appears verbatim in the (public) run log.
+          echo "::add-mask::$HASH"
           echo "password_hash=$HASH" >> $GITHUB_OUTPUT
 
       - name: Create Dynamic User-Data
@@ -339,8 +362,15 @@ jobs:
           # Escape special characters for sed
           ESCAPED_HASH=$(printf '%s\n' "$HASH" | sed 's/[[\.*^$/]/\\&/g')
           sed -i "s|password: \".*\"|password: \"$ESCAPED_HASH\"|" user-data
-          echo "Updated user-data password hash"
-          grep "password:" user-data
+          # Assert the substitution worked WITHOUT printing the matched line. The
+          # hash is derived from secrets.SSH_PASSWORD, and this repo is public, so
+          # echoing it would publish a crackable credential to the run log.
+          if grep -q 'password: "[$]6[$]' user-data; then
+            echo "user-data password hash substituted OK"
+          else
+            echo "::error::password hash substitution failed in user-data"
+            exit 1
+          fi
 
       - name: Create Variables File
         working-directory: ${{ env.DESKTOP_WORKING_DIR }}
@@ -494,6 +524,9 @@ jobs:
         run: |
           PASSWORD="${{ secrets.SSH_PASSWORD }}"
           HASH=$(openssl passwd -6 "$PASSWORD")
+          # GitHub masks registered secrets, but NOT values derived from them.
+          # Without this, the crypt hash appears verbatim in the (public) run log.
+          echo "::add-mask::$HASH"
           echo "password_hash=$HASH" >> $GITHUB_OUTPUT
 
       - name: Create Dynamic User-Data
@@ -504,8 +537,15 @@ jobs:
           # Escape special characters for sed
           ESCAPED_HASH=$(printf '%s\n' "$HASH" | sed 's/[[\.*^$/]/\\&/g')
           sed -i "s|password: \".*\"|password: \"$ESCAPED_HASH\"|" user-data
-          echo "Updated user-data password hash"
-          grep "password:" user-data
+          # Assert the substitution worked WITHOUT printing the matched line. The
+          # hash is derived from secrets.SSH_PASSWORD, and this repo is public, so
+          # echoing it would publish a crackable credential to the run log.
+          if grep -q 'password: "[$]6[$]' user-data; then
+            echo "user-data password hash substituted OK"
+          else
+            echo "::error::password hash substitution failed in user-data"
+            exit 1
+          fi
 
       - name: Create Variables File
         working-directory: ${{ env.DESKTOP_WORKING_DIR }}


### PR DESCRIPTION
Fixes the high-severity finding from the repo secret review.

## Problem

All four jobs printed the crypt hash of `secrets.SSH_PASSWORD` into the workflow log:

```yaml
sed -i "s|password: \".*\"|password: \"$ESCAPED_HASH\"|" user-data
echo "Updated user-data password hash"
grep "password:" user-data          # <-- prints $6$... verbatim
```

Confirmed in run 31240938599:

```
Create Dynamic User-Data    password: "$6$ltFW.1<truncated>"
```

## Why it was not caught

GitHub masks **registered secrets** in logs, so `secrets.SSH_PASSWORD` itself never appears. It does **not** mask values *derived* from them — `openssl passwd -6 "$PASSWORD"` output passes straight through. The protection you'd reasonably assume was covering this simply doesn't apply to derivations.

## Exposure

This repo is **public**, so Actions logs are world-readable. The step dates to at least 2025-09-30 and has run across **71 executed runs**, printing once per job (5 jobs per run). GitHub retains public-repo logs ~90 days, so recent runs are still readable.

Severity is bounded: this is a SHA-512 crypt hash, not plaintext, so the risk is offline cracking rather than instant compromise. It matters because that credential is the `ubuntu` user on every VM built from these templates, and the autoinstall grants it `NOPASSWD:ALL` sudo.

## Changes (×4 jobs)

**1. Mask the derived value at the source:**
```yaml
HASH=$(openssl passwd -6 "$PASSWORD")
echo "::add-mask::$HASH"
```
Any future accidental echo now renders as `***`.

**2. Assert without disclosing:**
```yaml
if grep -q 'password: "[$]6[$]' user-data; then
  echo "user-data password hash substituted OK"
else
  echo "::error::password hash substitution failed in user-data"
  exit 1
fi
```

This is also a small correctness win: the old `grep` never checked its result, so a failed `sed` would have silently produced a template with the placeholder password baked in. The new form fails the job loudly.

## Verification

- No `grep "password:"` remains — all 4 removed
- 4 `add-mask` directives and 4 assertions present
- YAML parses, all four jobs intact (`validate`, `build`, `validate-desktop`, `build-desktop`)
- Assertion logic tested against a real `openssl passwd -6` hash, both match and no-match cases

## Follow-up required (not in this PR)

**Rotate `SSH_PASSWORD` and rebuild templates.** This PR stops future disclosure; the already-published hash stays in existing logs until they age out, and may have been scraped. Rotation is what actually retires it.

## Unrelated finding surfaced during this work

Semgrep flagged the action pins in this file. Most notable: **`hashicorp/setup-packer@main`**, used 4×. A branch reference can be silently repointed by the owner at any time, and these jobs hold `PROXMOX_TOKEN`, `SSH_PASSWORD` and `TAILSCALE_AUTH_KEY`. `actions/checkout@v7` and `actions/upload-artifact@v7` are tags — mutable, but meaningfully lower risk than a branch head. Left out to keep this PR focused; worth a follow-up.