### PR TITLE
Pin the last two actions; no mutable refs remain

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/terraform-validate-and-plan.yml
+++ b/.github/workflows/terraform-validate-and-plan.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 


### PR DESCRIPTION
Completes the pinning started in #134.

## What

```
actions/setup-node        -> 820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
hashicorp/setup-terraform -> dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
```

Both live in the terraform workflows — including **`terraform-apply.yml`**, which applies infrastructure using Proxmox root credentials against Consul-backed state. That is the most privileged workflow in the repo, and it was the last one still executing code from mutable references.

## No behavioural change

Both major tags currently resolve to exactly their latest release commit:

| Action | Major tag | Latest release | |
|---|---|---|---|
| actions/setup-node | `v7` = `8207627860...` | `v7.0.0` = `8207627860...` | MATCH |
| hashicorp/setup-terraform | `v4` = `dfe3c3f878...` | `v4.0.1` = `dfe3c3f878...` | MATCH |

Verified by resolving each independently and comparing. This is a pure no-op today — it only removes the ability for those tags to be silently repointed later.

## Result: every reference in the repo is now pinned

```
actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1          # v7.0.1
actions/setup-node@820762786026740c76f36085b0efc47a31fe5020        # v7.0.0
actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
hashicorp/setup-packer@ce93c3c08a6c2ff2275bf4b54ff0d9a75f6c9789    # v3.4.0
hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
```

## Verification

- No `@v<major>`, `@main` or `@master` reference remains in any workflow
- YAML parses in both files, jobs intact
- Step inputs unchanged: `node-version: 24`, `terraform_version: ${{ env.TF_VERSION }}`
- Renovate keeps SHA pins current via the trailing version comments