### PR TITLE
Keep one daily-news ARC runner warm

### DIFF
--- a/infrastructure_tooling/arc_runner_scaleset_daily_news/values.yaml
+++ b/infrastructure_tooling/arc_runner_scaleset_daily_news/values.yaml
@@ -12,6 +12,19 @@ gha-runner-scale-set:
   # Runner configuration - use this as runs-on value
   runnerScaleSetName: "arc-k3s-daily-news"
 
+  # Keep one runner registered at all times so an ARC outage is visible from
+  # `kubectl -n arc-runners get pods` instead of going unnoticed. This scale set
+  # shares the arc-github-token secret with arc_runner_scaleset, so it was dead
+  # for the same four months (2026-04-20 to 2026-08-08) and for the same reason
+  # -- and nobody noticed, because with minRunners at the default 0 a dead
+  # listener and an idle scale set look identical.
+  #
+  # Note this does NOT bound the 24h queue ceiling, which is a GitHub-side limit
+  # on self-hosted jobs and is not configurable.
+  #
+  # maxRunners is deliberately left unset (unbounded), matching arc_runner_scaleset.
+  minRunners: 1
+
   # Container mode (recommended for K8s)
   containerMode:
     type: "kubernetes"


### PR DESCRIPTION
Closes the same detection gap #132 fixed for the homelab scale set.

## Why this one matters too

`arc-k3s-daily-news` shares the `arc-github-token` secret with `arc_runner_scaleset`, so it was dead for **exactly the same four months** (2026-04-20 → 2026-08-08) and for exactly the same reason. It came back automatically when #127 restored the secret.

It arguably went unnoticed *more* easily than the homelab set: that one at least had a weekly scheduled workflow whose cancellations eventually accumulated as visible evidence. This scale set serves `bmorri13/daily_news_app` and has no equivalent signal in this repo at all.

With `minRunners` at the default `0`, a dead listener and an idle scale set are indistinguishable from `kubectl -n arc-runners get pods`. A warm runner turns an outage into a missing pod.

## Scope

- `maxRunners` left unset (unbounded), matching `arc_runner_scaleset`
- As with #132, this does **not** bound the 24h queue ceiling — that is a GitHub-side limit on self-hosted jobs and is not configurable. This buys detection, not a shorter failure window.

## Capacity

Checked on k3s-01 before adding a second persistent runner:

| Metric | Value |
|---|---|
| CPU | 107m, 2% |
| Memory | 5275Mi, 32% |
| Disk | 259G free of 296G |

`local-path` PVCs are thin-provisioned, so the 10Gi claim costs little at rest.

## Verification

Rendered before pushing:

- `minRunners: 1` present on the `AutoscalingRunnerSet`
- chart still `gha-rs-0.13.1`, matching the deployed controller — see #129/#130 for why that must not move
- **zero** ExternalSecrets rendered, so the shared `arc-github-token` stays owned solely by the homelab chart and the two ArgoCD apps do not contend for it

## After merge

`arc-runner-daily-news-k3s` has `selfHeal: true`, so it deploys itself. Expect a persistent `arc-k3s-daily-news-*-runner-*` pod within a few minutes.